### PR TITLE
feat: implement favourites page logic

### DIFF
--- a/app/[locale]/(shop)/favourites/page.tsx
+++ b/app/[locale]/(shop)/favourites/page.tsx
@@ -1,18 +1,8 @@
 import React from 'react';
-import classes from './favourites.module.scss';
-import { Layout } from '@/app/components/ui/Layout/Layout';
+
+import FavouritesPage from '@/app/components/layout/FavouritesPage/FavouritesPage';
 function Page() {
-  return (
-    <>
-    <section className="section">
-        <h1 className={`main-heading`}>Favourites</h1>
-        <span className={classes.info}>95 models</span>
-      </section>
-      <section className="section">
-        <Layout />
-      </section>
-    </>
-  );
+  return <FavouritesPage />;
 }
 
 export default Page;

--- a/app/components/layout/FavouritesPage/FavouritesPage.module.scss
+++ b/app/components/layout/FavouritesPage/FavouritesPage.module.scss
@@ -1,0 +1,5 @@
+.info {
+  color: var(--gray-secondary);
+  font-family: 'Mont', sans-serif;
+  font-size: 0.875rem;
+}

--- a/app/components/layout/FavouritesPage/FavouritesPage.tsx
+++ b/app/components/layout/FavouritesPage/FavouritesPage.tsx
@@ -1,0 +1,21 @@
+'use client';
+import React from 'react';
+import classes from './FavouritesPage.module.scss';
+import { useAppSelector } from '@/app/stores/hooks';
+import { Layout } from '../../ui/Layout/Layout';
+function FavouritesPage() {
+  const { favouritesProducts } = useAppSelector((state) => state.favourites);
+  return (
+    <>
+      <section className="section">
+        <h1 className={`main-heading`}>Favourites</h1>
+        <span className={classes.info}>{favouritesProducts.length} models</span>
+      </section>
+      <section className="section">
+        <Layout products={favouritesProducts} />
+      </section>
+    </>
+  );
+}
+
+export default FavouritesPage;

--- a/app/components/ui/Button/LikeButton/LikeButton.tsx
+++ b/app/components/ui/Button/LikeButton/LikeButton.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import classes from './LikeButton.module.scss';
 import { Heart } from '../../Icons/Heart';
 
-export function LikeButton() {
+type Props = {
+  onClick?: () => void;
+  filled?: boolean;
+};
+export function LikeButton({ onClick, filled = false }: Props) {
   return (
-    <button className={classes.button}>
-      <Heart />
+    <button className={classes.button} onClick={onClick}>
+      <Heart filled={filled} />
     </button>
   );
 }

--- a/app/components/ui/ProductCard/ProductCard.tsx
+++ b/app/components/ui/ProductCard/ProductCard.tsx
@@ -1,15 +1,23 @@
+'use client';
 import React from 'react';
-import phoneImage from './Image/Phone.png';
 import classes from './ProductCard.module.scss';
 import { AddButton } from '../Button/AddButton/AddButton';
 import { LikeButton } from '../Button/LikeButton/LikeButton';
 import Link from 'next/link';
 import { Product } from '@/app/types/product';
+import { useAppDispatch, useAppSelector } from '@/app/stores/hooks';
+import { toggleFavourites } from '@/app/stores/slices/favouritesSlice';
 type ProductProps = {
   product: Product;
 };
 export function ProductCard({ product }: ProductProps) {
   const link = `/${product.category}/${product.itemId}`;
+  const { favouritesProducts } = useAppSelector((state) => state.favourites);
+  const isFavourite = favouritesProducts.some((p) => p.itemId === product.itemId);
+  const dispatch = useAppDispatch();
+  const toggleLike = () => {
+    dispatch(toggleFavourites(product));
+  };
   return (
     <div className={classes.card}>
       <div className={classes.image}>
@@ -42,7 +50,7 @@ export function ProductCard({ product }: ProductProps) {
 
       <div className={classes.buttons}>
         <AddButton product={product} />
-        <LikeButton />
+        <LikeButton onClick={toggleLike} filled={isFavourite} />
       </div>
     </div>
   );

--- a/app/components/ui/ProductCustomization/ProductCustomization.tsx
+++ b/app/components/ui/ProductCustomization/ProductCustomization.tsx
@@ -4,14 +4,13 @@ import { CapacityButton } from '../Button/CapacityButton/CapacityButton';
 import { ColorChangButton } from '../Button/ColorChangButton/ColorChangButton';
 import { LikeButton } from '../Button/LikeButton/LikeButton';
 
-
 export function ProductCustomization() {
   return (
     <div className={classes.castomization}>
       <div>
         <div className={classes.head__text}>
           <p className={classes.color__text}>Available colors</p>
-          <p className={classes.id__text}>ID: 1234</p> 
+          <p className={classes.id__text}>ID: 1234</p>
           {/*  Display product ID instead of hardcoded value  */}
         </div>
 
@@ -38,7 +37,7 @@ export function ProductCustomization() {
       <div className={classes.buttons}>
         {/* <AddButton product={product} /> */}
         {/* when data is there */}
-        <LikeButton />
+        <LikeButton filled={false} />
       </div>
 
       <div className={classes.blok}>

--- a/app/components/ui/ThemeInit/ThemeInit.tsx
+++ b/app/components/ui/ThemeInit/ThemeInit.tsx
@@ -4,12 +4,14 @@ import {useEffect} from "react";
 import {useDispatch} from "react-redux";
 import {AppDispatch} from "@/app/stores";
 import {initTheme} from "@/app/stores/slices/mainSlice";
+import { initFavourites } from "@/app/stores/slices/favouritesSlice";
 
 export function ThemeInit() {
     const dispatch = useDispatch<AppDispatch>();
 
     useEffect(() => {
         dispatch(initTheme());
+        dispatch(initFavourites())
     }, [dispatch]);
 
     return null;

--- a/app/stores/index.ts
+++ b/app/stores/index.ts
@@ -1,44 +1,17 @@
-import { configureStore, createListenerMiddleware, isAnyOf } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
 import productReducer from './slices/productSlice';
 import mainReducer from './slices/mainSlice';
-import cartReducer, { addItem, removeItem, incrementQuantity, decrementQuantity, setCartItems } from './slices/cartSlice';
-
-// const localStorageMiddleware = createListenerMiddleware();
-
-// localStorageMiddleware.startListening({
-//   matcher: isAnyOf(addItem, removeItem, incrementQuantity, decrementQuantity, setCartItems),
-//   effect: (action, listenerApi) => {
-//     localStorage.setItem('cartState', JSON.stringify((listenerApi.getState() as RootState).cart));
-//   },
-// });
+import favouritesReducer from './slices/favouritesSlice';
+import cartReducer from './slices/cartSlice';
 
 export const store = configureStore({
   reducer: {
     products: productReducer,
     main: mainReducer,
     cart: cartReducer,
+    favourites: favouritesReducer,
   },
-  // middleware: (getDefaultMiddleware) =>
-  //   getDefaultMiddleware().prepend(localStorageMiddleware.middleware),
 });
-
-// const loadInitialCartState = () => {
-//   try {
-//     const serializedState = localStorage.getItem('cartState');
-//     if (serializedState === null) {
-//       return undefined;
-//     }
-//     return JSON.parse(serializedState);
-//   } catch (error) {
-//     console.error('Error loading cart state from localStorage:', error);
-//     return undefined;
-//   }
-// };
-
-// const preloadedCartState = loadInitialCartState();
-// if (preloadedCartState) {
-//   store.dispatch(setCartItems(preloadedCartState.items));
-// }
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/app/stores/slices/favouritesSlice.ts
+++ b/app/stores/slices/favouritesSlice.ts
@@ -1,0 +1,47 @@
+import { Product } from '../../types/product';
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { getProducts } from '@/app/helpers/products/getProducts';
+
+interface FavouritesState {
+  favouritesProducts: Product[];
+}
+
+const initialState: FavouritesState = {
+  favouritesProducts: [],
+};
+
+export const getProductsStore = createAsyncThunk('products/get', async () => {
+  return await getProducts();
+});
+
+const favouritesSlice = createSlice({
+  name: 'favourites',
+  initialState,
+  reducers: {
+    initFavourites(state) {
+      const dataFromStorage = localStorage.getItem('favourites');
+      let initFavourites = [];
+      if (dataFromStorage) {
+        initFavourites = JSON.parse(dataFromStorage);
+      }
+      state.favouritesProducts = initFavourites;
+    },
+    toggleFavourites(state: FavouritesState, action: PayloadAction<Product>) {
+      const existingProduct = state.favouritesProducts.some(
+        (p) => p.itemId === action.payload.itemId,
+      );
+      if (existingProduct) {
+        state.favouritesProducts = state.favouritesProducts.filter(
+          (p) => p.itemId !== action.payload.itemId,
+        );
+      } else {
+        state.favouritesProducts.push(action.payload);
+      }
+
+      localStorage.setItem('favourites', JSON.stringify(state.favouritesProducts));
+    },
+  },
+});
+
+export const { initFavourites, toggleFavourites } = favouritesSlice.actions;
+export default favouritesSlice.reducer;


### PR DESCRIPTION
Changes:

- created favouritesSlice with logic for init favourites from localStorage and toggleFavourites
- in ProductCard component added logic for Like Button (will be separated when product details page is ready)
- in LikeButton Component created type for Props and call callback function
- moved layout from favourites page into separate component, so the page remains ssr.
- in ThemeInit called initFavourites function with dispatch
